### PR TITLE
fix install_ddrig_deps script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .Rproj.user
 .idea
 .Ruserdata
+.DS_Store

--- a/scripts/_install_ddrig_deps.R
+++ b/scripts/_install_ddrig_deps.R
@@ -7,7 +7,7 @@ r_packages <- c("dplyr",
               "ggrepel",
               "NCmisc",
               "lintr",
-              "precommit") # ggforce tends to have issues installing due to RcppEigen
+              "precommit")
 
 missing_r_packages <- r_packages[!(r_packages %in% installed.packages()[, "Package"])]
 if (length(missing_r_packages)) install.packages(missing_r_packages, repo = "http://cran.rstudio.com/")

--- a/scripts/_install_ddrig_deps.R
+++ b/scripts/_install_ddrig_deps.R
@@ -1,0 +1,22 @@
+# If a package is installed, it will be loaded. If any are not, the missing package(s) will be installed
+# and then loaded.
+
+r_packages <- c("dplyr",
+              "tidyverse",
+              "ggplot2",
+              "ggrepel",
+              "NCmisc",
+              "lintr",
+              "precommit",
+              "ggforce") # ggforce tends to have issues installing due to RcppEigen
+
+missing_r_packages <- r_packages[!(r_packages %in% installed.packages()[, "Package"])]
+if (length(missing_r_packages)) install.packages(missing_r_packages, repo = "http://cran.rstudio.com/")
+
+github_packages <- c("precommit")
+
+missing_gh_packages <- github_packages[!(github_packages %in% installed.packages()[, "Package"])]
+lapply(missing_gh_packages, remotes::install_github)
+
+# Initialize precommit.
+precommit::use_precommit()

--- a/scripts/_install_ddrig_deps.R
+++ b/scripts/_install_ddrig_deps.R
@@ -7,8 +7,7 @@ r_packages <- c("dplyr",
               "ggrepel",
               "NCmisc",
               "lintr",
-              "precommit",
-              "ggforce") # ggforce tends to have issues installing due to RcppEigen
+              "precommit") # ggforce tends to have issues installing due to RcppEigen
 
 missing_r_packages <- r_packages[!(r_packages %in% installed.packages()[, "Package"])]
 if (length(missing_r_packages)) install.packages(missing_r_packages, repo = "http://cran.rstudio.com/")

--- a/scripts/install_ddrig_deps.sh
+++ b/scripts/install_ddrig_deps.sh
@@ -2,37 +2,12 @@
 
 if ! pre-commit --version &> /dev/null
 then
-    echo "pre-commit is not installed. Please install pre-commit using pip or brew."
+    echo "pre-commit is not installed. Please install pre-commit using pip or brew.\n"
     exit
 fi
 
-
-
-# Standard R Packages.
-declare -a cran_packages=(
-	"ggforce"
-	"dplyr"
-	"tidyverse"
-	"ggplot2"
-	"ggrepel"
-	"NCmisc"
-)
-
 echo "Installing R Packages..."
-for pkg in "${cran_packages[@]}"; do
-	Rscript -e "if (!'$pkg' %in% rownames(installed.packages())) install.packages('$pkg', repo='http://cran.rstudio.com/')"
-done
 
-
-# Github packages.
-declare -a github_packages=(
-	"lorenzwalthert/precommit"
-)
-
-
-echo "Installing GitHub Packages..."
-for pkg in "${github_packages[@]}"; do
-	Rscript -e "if (!'$pkg' %in% rownames(installed.packages())) remotes::install_github('$pkg')"
-done
+time Rscript -e 'source("./scripts/_install_ddrig_deps.R")'
 
 echo "Installation complete!"

--- a/scripts/install_ddrig_deps.sh
+++ b/scripts/install_ddrig_deps.sh
@@ -6,7 +6,7 @@ then
     exit
 fi
 
-echo "Installing R Packages..."
+echo "Installing DDRIG dependencies..."
 
 time Rscript -e 'source("./scripts/_install_ddrig_deps.R")'
 


### PR DESCRIPTION
changes the `install_ddrig_deps.sh` to instead call `_install_ddrig_deps.R`, as running an actual R script is a cleaner, smoother way to handle running R from bash. the `.R` file is prefixed with an `_` which is standard practice for implying that something (whether it's a file in a repo or a function in code) is meant for internal use.

Anyone who wants to pull the DDRIG repo can now simply call `./scripts/install_ddrig_deps.sh` and all libraries will be installed within a matter of about 15 minutes (if the user has _none_ of the libraries installed at all).